### PR TITLE
[NYM-19] 같은 작물명 행 제거

### DIFF
--- a/crop/crop_data_filter.py
+++ b/crop/crop_data_filter.py
@@ -4,13 +4,16 @@ import pandas as pd
 df = pd.read_excel('/Users/kimdoyeon/Downloads/crop.xlsx', engine='openpyxl')
 
 # 카테고리, 서브제목1,서브내용2,서브제목3,서브제목4,서브내용4,서브내용5,등록일 제거
-delete = ['카테고리', '요약글', '서브제목1', '서브제목2','서브내용3','서브내용4', '서브내용2', '서브제목3', '서브제목4', '서브제목5', '서브내용5', '등록일']
+delete = ['카테고리', '요약글', '서브제목1', '서브제목2', '서브내용3', '서브내용4', '서브내용2', '서브제목3', '서브제목4', '서브제목5', '서브내용5', '등록일']
 
 for i in delete:
     df = df.drop(columns=[i])
 
-for value in ['제목','서브내용1'] :
+for value in ['제목', '서브내용1']:
     df[value] = df[value].str.replace('<br>', '')
+
+# 제목 중복 시 행 제거
+df = df.drop_duplicates(subset='제목')
 # 결과 저장
 output_path = '/Users/kimdoyeon/Desktop/nym-data/cleaned_crop.xlsx'
 df.to_excel(output_path, index=False)


### PR DESCRIPTION
## #️⃣연관된 이슈
#2 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 기존 엑셀파일에서 중복되는 작물명애 대해 `postgreSQL` 데이터 삽입 시 `crop_name`에 대해 `unique=true` 설정으로 인한 오류 발생
### 해결방법
1. DB에서 `crop_name`에 대해 `unique=true` 설정은 필수이므로 변경 불가
2. 중복되는 작물명에 대해 해당 행을 삭제 처리 로직을 추가. 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
